### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/js/generator-github-container-build/generators/app/templates/github/container-build/action.yaml
+++ b/js/generator-github-container-build/generators/app/templates/github/container-build/action.yaml
@@ -37,7 +37,7 @@ runs:
     - name: Log in to the Container registry
       uses: docker/login-action@latest
       with:
-        registry: gchr.io
+        registry: ghcr.io
         username: ${{ inputs.actor }}
         password: ${{ inputs.github_token }}
 


### PR DESCRIPTION
Hi `OctopusSamples/content-team-apps`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.